### PR TITLE
FEAT: Rework undo command. Replace stack in game engine

### DIFF
--- a/FifteenPuzzle/Core/Interfaces/IGameEngine.cs
+++ b/FifteenPuzzle/Core/Interfaces/IGameEngine.cs
@@ -7,8 +7,6 @@ public interface IGameEngine : IObservable
     bool IsRunning { get; }
     bool PuzzleSolved { get; }
 
-    IReadOnlyList<Move> Moves { get; }
-
     void Initialize(bool regenerateSeed = true);
     bool MakeMove(Move move);
     void UndoLastMove();

--- a/FifteenPuzzle/Core/Utils/CircularBuffer.cs
+++ b/FifteenPuzzle/Core/Utils/CircularBuffer.cs
@@ -1,0 +1,28 @@
+namespace FifteenPuzzle.Core.Utils;
+
+public class CircularBuffer<T>(int n)
+{
+    private int _head;
+    private readonly T[] _buffer = new T[n];
+
+    public int Count { get; private set; }
+
+    public void Push(T value)
+    {
+        Count = Count++ <= _buffer.Length ? Count++ : _buffer.Length;
+
+        _buffer[_head] = value;
+        _head = (_head + 1) % _buffer.Length;
+    }
+
+    public T Pop()
+    {
+        if (Count is 0)
+            throw new InvalidOperationException("Buffer is empty");
+
+        Count--;
+        _head = _head - 1 >= 0 ? _head - 1 : _buffer.Length - 1;
+
+        return _buffer[_head];
+    }
+}

--- a/FifteenPuzzle/Program.cs
+++ b/FifteenPuzzle/Program.cs
@@ -3,7 +3,6 @@ using FifteenPuzzle.Cli.Commands;
 using FifteenPuzzle.Cli.Console;
 using FifteenPuzzle.Core.Events.Observers;
 using FifteenPuzzle.Core.Interfaces;
-using FifteenPuzzle.Core.Models;
 using FifteenPuzzle.Core.Services;
 using FifteenPuzzle.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;


### PR DESCRIPTION
I replaced `Stack<Move>` in game engine with a `CircularBuffer<Move>` to avoid too deep stacks. This brings a limitation to the undo command (can be used for up to 8 prev moves)